### PR TITLE
Vfd 113 fix runtime permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _ReSharper*/
 # Locally built
 out/
 TMTResponseOutputDebug.txt
+release/

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ The endpoint should be available at: `http://localhost:5286/test/lassipatanen/Jo
 
 ### Locally testing the authentication with the Authentication GW
 
-In local development the [Authentication GW](https://github.com/Virtual-Finland-Development/authentication-gw) checks are disabled by default. To enable them, you need to set the `ASPNETCORE_ENVIRONMENT` environment variable to `Staging` or `Production` when running the app. For example:
+In local development the [Authentication GW](https://github.com/Virtual-Finland-Development/authentication-gw) checks are disabled by default. To enable them, you need to set the `ASPNETCORE_ENVIRONMENT` environment variable to `Development` or `Staging` when running the app. For example:
 
 ```
-export ASPNETCORE_ENVIRONMENT=Staging
+export ASPNETCORE_ENVIRONMENT=Development
 dotnet run --project ./src/TMTProductizer/TMTProductizer.csproj
 ```
 
-The auth headers `Authorization` and `X-Authorization-Provider` are required in every enviroment stage. For stages `Development` and `Mock` the values for these headers are not important, as long as they are present.
+The auth headers `Authorization` and `X-Authorization-Provider` are required in every enviroment stage. For stages `Local` and `Mock` the values for these headers are not important, as long as they are present.
 
 ### Generating models from Open API spec
 

--- a/deployment/TmtProductizerStack.cs
+++ b/deployment/TmtProductizerStack.cs
@@ -51,6 +51,32 @@ public class TmtProductizerStack : Stack
             })
         });
 
+        // AWS Secrets Manager Policy
+        var secretsManagerPolicy = new Policy($"{projectName}-secrets-manager-policy-{environment}", new()
+        {
+            Description = "Read access to secrets manager",
+            PolicyDocument = @"{
+                ""Version"": ""2012-10-17"",
+                ""Statement"": [
+                    {
+                    ""Action"": [
+                        ""secretsmanager:GetSecretValue""
+                    ],
+                    ""Effect"": ""Allow"",
+                    ""Resource"": ""arn:aws:secretsmanager:eu-north-1:433482540854:secret:tmt-api/azure-b2c-auth/client-secrets-K7W9Iq""
+                    }
+                ]
+                }
+            ",
+        });
+
+        // Attach secrets manager policy
+        new RolePolicyAttachment($"{projectName}-secrets-manager-policy-attachment-{environment}", new()
+        {
+            Role = role.Name,
+            PolicyArn = secretsManagerPolicy.Arn,
+        });
+
         var rolePolicyAttachment = new RolePolicyAttachment($"{projectName}-lambda-role-attachment-{environment}",
             new RolePolicyAttachmentArgs
             {

--- a/deployment/TmtProductizerStack.cs
+++ b/deployment/TmtProductizerStack.cs
@@ -68,6 +68,7 @@ public class TmtProductizerStack : Stack
                 ]
                 }
             ",
+            Tags = tags
         });
 
         // Attach secrets manager policy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "5286:5286"
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Local
       - ASPNETCORE_URLS=http://0.0.0.0:5286
       - AWS_PROFILE=virtualfinland
     volumes:

--- a/src/TMTProductizer/Properties/launchSettings.json
+++ b/src/TMTProductizer/Properties/launchSettings.json
@@ -16,7 +16,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5286",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     }
   }

--- a/src/TMTProductizer/Services/AuthorizationService.cs
+++ b/src/TMTProductizer/Services/AuthorizationService.cs
@@ -10,23 +10,25 @@ public class AuthorizationService : IAuthorizationService
     public AuthorizationService(HttpClient client, IHostEnvironment env)
     {
         _client = client;
-        _skipAuthorizationCheck = env.IsDevelopment() || env.IsEnvironment("Mock");
+        _skipAuthorizationCheck = env.IsEnvironment("Local") || env.IsEnvironment("Mock");
     }
 
     public async Task Authorize(HttpRequest request)
     {
         // Get the auth headers from the origin request
         var originHeaders = request.Headers.ToDictionary(x => x.Key.ToLowerInvariant(), x => x.Value.ToString());
-        
+
         // Prep authorization request
-        if (!originHeaders.ContainsKey("authorization") || !originHeaders.ContainsKey("x-authorization-provider")) {
+        if (!originHeaders.ContainsKey("authorization") || !originHeaders.ContainsKey("x-authorization-provider"))
+        {
             throw new HttpRequestException("Missing headers", null, HttpStatusCode.Unauthorized); // Throws 401 if no auth headers
         }
 
         // Skip on local development, but require headers present (above)
         if (_skipAuthorizationCheck) return;
 
-        var authorizeRequest = new HttpRequestMessage {
+        var authorizeRequest = new HttpRequestMessage
+        {
             RequestUri = new Uri($"{_client.BaseAddress}authorize"),
             Method = HttpMethod.Post,
             Headers = {
@@ -35,10 +37,11 @@ public class AuthorizationService : IAuthorizationService
                 { "x-authorization-context", "TMT-productizer" },
             }
         };
-        
+
         // Engage
-        var response = await _client.SendAsync(authorizeRequest); 
-        if (!response.IsSuccessStatusCode) {
+        var response = await _client.SendAsync(authorizeRequest);
+        if (!response.IsSuccessStatusCode)
+        {
             throw new HttpRequestException("Access Denied", null, HttpStatusCode.Unauthorized); // Throw 401 if not authorized.
         }
     }


### PR DESCRIPTION
- Allows the use of secrets manager on the live enviroments
- changed the local developmenting env to "Local" as the previous value "Development" is a live-env