### PR TITLE
fix: data-definition mismatch

### DIFF
--- a/src/TMTProductizer/Models/JobPosting.cs
+++ b/src/TMTProductizer/Models/JobPosting.cs
@@ -19,6 +19,6 @@ public class BasicInfo
 
 public class Location
 {
-    public string City { get; set; } = null!;
+    public string Municipality { get; set; } = null!;
     public string Postcode { get; set; } = null!;
 }

--- a/src/TMTProductizer/Models/JobPosting.cs
+++ b/src/TMTProductizer/Models/JobPosting.cs
@@ -2,7 +2,7 @@ namespace TMTProductizer.Models;
 
 public class Job
 {
-    public string? Employer { get; set; }
+    public string Employer { get; set; } = string.Empty;
     public Location Location { get; set; } = null!;
     public BasicInfo BasicInfo { get; set; } = null!;
     public DateTime PublishedAt { get; set; }
@@ -12,13 +12,13 @@ public class Job
 
 public class BasicInfo
 {
-    public string? Title { get; set; }
-    public string? Description { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
     public string WorkTimeType { get; set; } = null!;
 }
 
 public class Location
 {
-    public string Municipality { get; set; } = null!;
+    public string Municipality { get; set; } = string.Empty;
     public string Postcode { get; set; } = null!;
 }

--- a/src/TMTProductizer/Services/JobService.cs
+++ b/src/TMTProductizer/Services/JobService.cs
@@ -68,7 +68,7 @@ public class JobService : IJobService
             Employer = ilmoitus.IlmoittajanNimi.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString(),
             Location = new Location
             {
-                City = ilmoitus.Sijainti.Toimipaikka.Postitoimipaikka,
+                Municipality = ilmoitus.Sijainti.Toimipaikka.Postitoimipaikka,
                 Postcode = ilmoitus.Sijainti.Toimipaikka.Postinumero
             },
             BasicInfo = new BasicInfo

--- a/src/TMTProductizer/Services/JobService.cs
+++ b/src/TMTProductizer/Services/JobService.cs
@@ -65,7 +65,7 @@ public class JobService : IJobService
 
         jobs.AddRange(result.Ilmoitukset.Select(ilmoitus => new Job
         {
-            Employer = ilmoitus.IlmoittajanNimi.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString(),
+            Employer = ilmoitus.IlmoittajanNimi.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString() ?? string.Empty,
             Location = new Location
             {
                 Municipality = ilmoitus.Sijainti.Toimipaikka.Postitoimipaikka,
@@ -73,9 +73,9 @@ public class JobService : IJobService
             },
             BasicInfo = new BasicInfo
             {
-                Title = ilmoitus.Perustiedot.TyonOtsikko.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString(),
+                Title = ilmoitus.Perustiedot.TyonOtsikko.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString() ?? string.Empty,
                 Description =
-                    ilmoitus.Perustiedot.TyonKuvaus.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString(),
+                    ilmoitus.Perustiedot.TyonKuvaus.FirstOrDefault(x => x.KieliKoodi == "fi")?.Arvo.ToString() ?? string.Empty,
                 WorkTimeType = ilmoitus.Perustiedot.TyoAika
             },
             PublishedAt = ilmoitus.Julkaisupvm,


### PR DESCRIPTION
fix: 
- data definition says Location.Municipality, productizer outputted a Location.City
- employer, title and description as empty-string instead of null