### PR TITLE
refactor: cache class rearrangement

### DIFF
--- a/src/TMTCacheUpdater/Function.cs
+++ b/src/TMTCacheUpdater/Function.cs
@@ -25,6 +25,7 @@ public class Function
             services =>
                 services.AddScoped<IConfiguration>(i => configuration)
                     .AddScoped<ITMTJobsFetcher, TMTJobsFetcher>()
+                    .AddScoped<ITMTAPIResultsCacheService, TMTAPIResultsCacheService>()
                     .AddScoped<IAuthorizationService, AuthGWAuthorizationService>()
                     .AddScoped<ISecretsManager, SecretsManager>()
                     .AddScoped<IAPIAuthorizationService, TMTAPIAuthorizationService>()

--- a/src/TMTProductizer.UnitTests/Services/JobServiceTests.cs
+++ b/src/TMTProductizer.UnitTests/Services/JobServiceTests.cs
@@ -7,7 +7,6 @@ using Moq.Protected;
 using TMTProductizer.Models;
 using TMTProductizer.Models.Cache.TMT;
 using TMTProductizer.Services;
-using TMTProductizer.Services.AWS;
 using TMTProductizer.UnitTests.Mocks;
 using TMTProductizer.Utils;
 
@@ -40,7 +39,7 @@ public class JobServiceTests
         var tmtAuthorizationService = new Mock<IAPIAuthorizationService>();
         tmtAuthorizationService.Setup(service => service.GetAPIAuthorizationPackage())
             .ReturnsAsync(new APIAuthorizationPackage());
-        var tmtApiResultsCacheService = new Mock<IS3BucketCache>();
+        var tmtApiResultsCacheService = new Mock<ITMTAPIResultsCacheService>();
         var jobFetcher = new Mock<ITMTJobsFetcher>();
         jobFetcher.Setup(service => service.FetchTMTAPIResults()).ReturnsAsync(cachedResults);
 
@@ -90,7 +89,7 @@ public class JobServiceTests
         var tmtAuthorizationService = new Mock<IAPIAuthorizationService>();
         tmtAuthorizationService.Setup(service => service.GetAPIAuthorizationPackage())
             .ReturnsAsync(new APIAuthorizationPackage());
-        var tmtApiResultsCacheService = new Mock<IS3BucketCache>();
+        var tmtApiResultsCacheService = new Mock<ITMTAPIResultsCacheService>();
 
         var query = new JobsRequest
         {

--- a/src/TMTProductizer/Program.cs
+++ b/src/TMTProductizer/Program.cs
@@ -7,6 +7,7 @@ using TMTProductizer.Utils;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSingleton<IJobService, JobService>();
 builder.Services.AddSingleton<ITMTJobsFetcher, TMTJobsFetcher>();
+builder.Services.AddSingleton<ITMTAPIResultsCacheService, TMTAPIResultsCacheService>();
 builder.Services.AddSingleton<IAuthorizationService, AuthGWAuthorizationService>();
 builder.Services.AddSingleton<ISecretsManager, SecretsManager>();
 builder.Services.AddSingleton<IAPIAuthorizationService, TMTAPIAuthorizationService>();

--- a/src/TMTProductizer/Services/AWS/IS3BucketCache.cs
+++ b/src/TMTProductizer/Services/AWS/IS3BucketCache.cs
@@ -1,2 +1,5 @@
 namespace TMTProductizer.Services.AWS;
-public interface IS3BucketCache : ICacheService { }
+public interface IS3BucketCache : ICacheService
+{
+    public void SetBucketName(string bucketName);
+}

--- a/src/TMTProductizer/Services/ITMTAPIResultsCacheService.cs
+++ b/src/TMTProductizer/Services/ITMTAPIResultsCacheService.cs
@@ -1,0 +1,15 @@
+using TMTProductizer.Models.Cache.TMT;
+
+namespace TMTProductizer.Services;
+public interface ITMTAPIResultsCacheService
+{
+    /// <summary>
+    /// Search from local cache, then S3
+    /// </summary>
+    public Task<CachedHakutulos?> GetCachedHakutulos();
+
+    /// <summary>
+    /// Save to S3
+    /// </summary>
+    public Task SaveCachedHakutulos(CachedHakutulos cachedResults);
+}

--- a/src/TMTProductizer/Services/TMTAPIResultsCacheService.cs
+++ b/src/TMTProductizer/Services/TMTAPIResultsCacheService.cs
@@ -1,0 +1,47 @@
+using TMTProductizer.Models.Cache.TMT;
+using TMTProductizer.Services.AWS;
+
+namespace TMTProductizer.Services;
+
+public class TMTAPIResultsCacheService : ITMTAPIResultsCacheService
+{
+    private readonly IS3BucketCache _s3BucketCache;
+    private readonly ILogger<ITMTAPIResultsCacheService> _logger;
+    private readonly ILocalFileCache _localFileCache;
+
+    private readonly string _tmtCacheKey = "TMTJobResults";
+    private readonly int _tmtCacheTTL = 24 * 60 * 60; // 24 h
+
+    public TMTAPIResultsCacheService(IConfiguration configuration, ILogger<ITMTAPIResultsCacheService> logger, IS3BucketCache s3BucketCache, ILocalFileCache localFileCache)
+    {
+        _logger = logger;
+        _s3BucketCache = s3BucketCache;
+        _s3BucketCache.SetBucketName(configuration.GetSection("S3BucketCacheName").Value);
+        _localFileCache = localFileCache;
+    }
+
+    public async Task<CachedHakutulos?> GetCachedHakutulos()
+    {
+        // First try from the faster local cache
+        var response = await _localFileCache.GetCacheItem<CachedHakutulos>(_tmtCacheKey);
+        if (response != null)
+        {
+            return response;
+        }
+
+        // If not found, try from S3
+        var cacheItem = await _s3BucketCache.GetCacheItem<CachedHakutulos>(_tmtCacheKey);
+        if (cacheItem != null)
+        {
+            // Save to local cache for faster access next time
+            await _localFileCache.SaveCacheItem<CachedHakutulos>(_tmtCacheKey, cacheItem);
+        }
+
+        return cacheItem;
+    }
+
+    public async Task SaveCachedHakutulos(CachedHakutulos cachedResults)
+    {
+        await _s3BucketCache.SaveCacheItem<CachedHakutulos>(_tmtCacheKey, cachedResults, _tmtCacheTTL);
+    }
+}

--- a/src/TMTProductizer/Services/TMTJobsFetcher.cs
+++ b/src/TMTProductizer/Services/TMTJobsFetcher.cs
@@ -3,7 +3,6 @@ using CodeGen.Api.TMT.Model;
 using TMTProductizer.Exceptions;
 using TMTProductizer.Models;
 using TMTProductizer.Models.Cache.TMT;
-using TMTProductizer.Services.AWS;
 using TMTProductizer.Utils;
 
 namespace TMTProductizer.Services;
@@ -13,12 +12,10 @@ public class TMTJobsFetcher : ITMTJobsFetcher
 
     private readonly IProxyHttpClientFactory _clientFactory;
     private readonly IAPIAuthorizationService _tmtApiAuthorizationService;
-    private readonly IS3BucketCache _tmtApiResultsCacheService;
+    private readonly ITMTAPIResultsCacheService _tmtApiResultsCacheService;
     private readonly ILogger<TMTJobsFetcher> _logger;
-    private readonly string _tmtCacheKey = "TMTJobResults";
-    private readonly int _tmtCacheTTL = 24 * 60 * 60; // 24 h
 
-    public TMTJobsFetcher(IProxyHttpClientFactory clientFactory, IAPIAuthorizationService tmtApiAuthorizationService, IS3BucketCache tmtApiResultsCacheService, ILogger<TMTJobsFetcher> logger)
+    public TMTJobsFetcher(IProxyHttpClientFactory clientFactory, IAPIAuthorizationService tmtApiAuthorizationService, ITMTAPIResultsCacheService tmtApiResultsCacheService, ILogger<TMTJobsFetcher> logger)
     {
         _clientFactory = clientFactory;
         _tmtApiAuthorizationService = tmtApiAuthorizationService;
@@ -31,7 +28,7 @@ public class TMTJobsFetcher : ITMTJobsFetcher
     /// </summary>
     public async Task<CachedHakutulos> FetchTMTAPIResults()
     {
-        var cachedResults = await _tmtApiResultsCacheService.GetCacheItem<CachedHakutulos>(_tmtCacheKey);
+        var cachedResults = await _tmtApiResultsCacheService.GetCachedHakutulos();
         if (cachedResults != null)
         {
             _logger.LogInformation("Found TMT API results from cache");
@@ -55,7 +52,7 @@ public class TMTJobsFetcher : ITMTJobsFetcher
             // Transform the Hakutulos to CachedHakutulos
             var cachedResults = new CachedHakutulos(results);
             // Save the results to cache
-            await _tmtApiResultsCacheService.SaveCacheItem(_tmtCacheKey, cachedResults, _tmtCacheTTL);
+            await _tmtApiResultsCacheService.SaveCachedHakutulos(cachedResults);
             _logger.LogInformation("Saving complete");
         }
         else


### PR DESCRIPTION
- simplify fetcher cache tooling with a ITMTAPIResultsCacheService 
- s3bucket cache no longer handles local file speedups.